### PR TITLE
Fix media_folder and image field

### DIFF
--- a/www/admin/config.yml
+++ b/www/admin/config.yml
@@ -8,8 +8,9 @@ production:
       name: github-api
       repo: TausS/flanoer # Path to your Github repository
       branch: master # Branch to update (master by default)
-      media_folder: "www/data/assets/uploads" # Folder where user uploaded files should go
 
+media_folder: "www/data/assets/uploads" # Folder where user uploaded files should go
+public_folder: "www" # Tells the CMS what folder assets are served from
 
 collections: # A list of collections the CMS should be able to edit
   - name: "product" # Used in routes, ie.: /admin/collections/:slug/edit
@@ -18,7 +19,7 @@ collections: # A list of collections the CMS should be able to edit
     create: false # Allow users to create new documents in this collection
 
     fields: # The fields each document in this collection have
-      - {label: "Image", name:"image", widget: "image"}
+      - {label: "Image", name: "image", widget: "image"}
       - {label: "Product title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Product description", name: "description", widget: "markdown"}
       - {label: "Price", name: "price", widget: "number"}


### PR DESCRIPTION
This moves the media_folder setting out from the "backend" settings to the general config.

It also adds a public_folder setting. Based on the media_folder files will be uploaded to www/data/assets/uploads.
The public_folder tells the CMS that the path to files stored in entries should be relative to www.

I also added a space in name:"image" since that field was not interpreted right...
